### PR TITLE
Add events and votes map

### DIFF
--- a/contracts/SecureBallotsDAO.clar
+++ b/contracts/SecureBallotsDAO.clar
@@ -202,6 +202,7 @@
                 quorum-required: quorum
             }
         )
+        (print {event: "create-proposal", proposal-id: new-id, creator: tx-sender, category: category, quorum: quorum})
         (var-set proposal-count new-id)
         (ok new-id)
     )
@@ -216,6 +217,7 @@
         (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_NOT_AUTHORIZED)
         (asserts! (not (get executed proposal-data)) ERR_INVALID_INPUT)
         (map-delete proposals proposal-id)
+        (print {event: "delete-proposal", proposal-id: proposal-id, by: tx-sender})
         (ok true)
     )
 )
@@ -235,6 +237,7 @@
             proposal-id
             (merge proposal-data {end-block: new-end-block})
         )
+        (print {event: "extend-proposal-deadline", proposal-id: proposal-id, by: tx-sender, new-end-block: new-end-block})
         (ok new-end-block)
     )
 )
@@ -254,6 +257,7 @@
             proposal-id
             (merge proposal-data {executed: true})
         )
+        (print {event: "execute-proposal", proposal-id: proposal-id, by: tx-sender})
         (ok true)
     )
 )
@@ -267,6 +271,7 @@
         (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_NOT_AUTHORIZED)
         (asserts! (is-none (index-of (var-get valid-voters) voter)) ERR_INVALID_INPUT)
         (var-set valid-voters (unwrap-panic (as-max-len? (append (var-get valid-voters) voter) u1000)))
+        (print {event: "add-voter", voter: voter, by: tx-sender})
         (ok true)
     )
 )
@@ -309,6 +314,7 @@
         
         ;; Remove voter weight
         (map-delete voter-weights voter)
+        (print {event: "remove-voter", voter: voter, by: tx-sender})
         (ok true)
     )
 )
@@ -319,6 +325,7 @@
         (asserts! (> weight u0) ERR_INVALID_WEIGHT)
         (asserts! (is-valid-voter voter) ERR_INVALID_VOTER)
         (map-set voter-weights voter weight)
+        (print {event: "set-voter-weight", voter: voter, weight: weight, by: tx-sender})
         (ok true)
     )
 )
@@ -339,6 +346,7 @@
         (asserts! (is-valid-voter tx-sender) ERR_INVALID_VOTER)
         
         (map-set vote-commitments tx-sender vote-hash)
+        (print {event: "commit-vote", proposal-id: proposal-id, voter: tx-sender})
         (ok true)
     )
 )
@@ -385,6 +393,7 @@
             (merge proposal {vote-count: (+ (get vote-count proposal) weight)})
         )
 
+        (print {event: "reveal-vote", proposal-id: proposal-id, voter: tx-sender, weight: weight})
         (ok true)
     ;; Read-only: get all proposal-ids voted by a user
     (define-read-only (get-user-votes (voter principal))
@@ -405,6 +414,7 @@
         (asserts! (not (is-eq tx-sender delegate)) ERR_INVALID_DELEGATION)
         
         (map-set delegations tx-sender delegate)
+        (print {event: "delegate-vote", delegator: tx-sender, delegate: delegate})
         (ok true)
     )
 )
@@ -414,6 +424,7 @@
     (begin
         (asserts! (is-some (map-get? delegations tx-sender)) ERR_INVALID_DELEGATION)
         (map-delete delegations tx-sender)
+        (print {event: "revoke-delegation", delegator: tx-sender})
         (ok true)
     )
 )
@@ -426,6 +437,7 @@
     (begin
         (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_NOT_AUTHORIZED)
         (var-set voting-open false)
+        (print {event: "close-voting", by: tx-sender})
         (ok true)
     )
 )
@@ -434,6 +446,7 @@
     (begin
         (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_NOT_AUTHORIZED)
         (var-set voting-open true)
+        (print {event: "open-voting", by: tx-sender})
         (ok true)
     )
 )
@@ -443,6 +456,7 @@
         (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_NOT_AUTHORIZED)
         (asserts! (> quorum u0) ERR_INVALID_INPUT)
         (var-set minimum-quorum quorum)
+        (print {event: "set-minimum-quorum", quorum: quorum, by: tx-sender})
         (ok true)
     )
 )


### PR DESCRIPTION
- Added voter-votes map to track and query all proposals voted by each user (user voting history).
- Added print events for all key DAO actions: proposal creation, deletion, extension, execution; voter management; vote commit and reveal; delegation and revocation; admin actions (open/close voting, set quorum, set voter weight).
- These changes improve transparency, allow easy integration with frontends, and enable users to query their voting history.